### PR TITLE
Feat/2fa-email

### DIFF
--- a/app/Notifications/TwoFactorEmailCode.php
+++ b/app/Notifications/TwoFactorEmailCode.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class TwoFactorEmailCode extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public string $code) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $expires = 10; // minutes
+
+        return (new MailMessage)
+            ->subject('Your sign-in code')
+            ->view('emails.twofa_code', [
+                'user' => $notifiable,
+                'code' => $this->code,
+                'expiresIn' => $expires,
+            ])
+            ->text('emails.twofa_code_plain', [
+                'user' => $notifiable,
+                'code' => $this->code,
+                'expiresIn' => $expires,
+            ]);
+    }
+}

--- a/resources/views/auth/twofa.blade.php
+++ b/resources/views/auth/twofa.blade.php
@@ -12,7 +12,7 @@
                     <i class="fa-solid fa-shield-halved"></i>
                 </div>
                 <h1>Two-Factor Authentication</h1>
-                <p>Enter the 6-digit code from your authenticator app or the code we sent to your email/SMS.</p>
+                <p>Enter a code from your authenticator app, or request a one‑time code by email.</p>
                 <ul class="auth-benefits">
                     <li><i class="fa-solid fa-lock"></i> Adds an extra layer of security</li>
                     <li><i class="fa-solid fa-mobile-screen"></i> Works with authenticator apps</li>
@@ -22,14 +22,41 @@
 
             <div class="auth-card" aria-live="polite">
                 <div id="twofa-alert" class="alert hidden" role="alert"></div>
+
+                <div class="auth-tabs" role="tablist">
+                    <button class="auth-tab active" role="tab" aria-selected="true" aria-controls="tab-totp" id="tabbtn-totp"><i class="fa-solid fa-mobile-screen-button" aria-hidden="true"></i> Authenticator</button>
+                    <button class="auth-tab" role="tab" aria-selected="false" aria-controls="tab-email" id="tabbtn-email"><i class="fa-solid fa-envelope" aria-hidden="true"></i> Email code</button>
+                    <button class="auth-tab" role="tab" aria-selected="false" aria-controls="tab-recovery" id="tabbtn-recovery"><i class="fa-solid fa-key" aria-hidden="true"></i> Recovery</button>
+                </div>
+
                 <form id="twofa-form" class="auth-form" novalidate>
-                    <div class="form-group">
-                        <label for="twofa-code" id="twofa-label">Enter 6‑digit code</label>
-                        <input type="text" id="twofa-code" name="code" inputmode="numeric" placeholder="123456" required>
-                        <small class="field-error" aria-live="assertive"></small>
+                    <input type="hidden" id="twofa-method" name="twofa-method" value="totp" />
+                    <div id="tab-totp" role="tabpanel" aria-labelledby="tabbtn-totp">
+                        <div class="form-group">
+                            <label for="twofa-code" id="twofa-label">Enter 6‑digit code</label>
+                            <input type="text" id="twofa-code" name="code" inputmode="numeric" placeholder="123456" required>
+                            <small class="field-error" aria-live="assertive"></small>
+                        </div>
                     </div>
-                    <div class="form-row" style="justify-content: space-between; gap: .75rem;">
-                        <button type="button" id="twofa-resend" class="btn btn-secondary" style="flex:1;">Resend</button>
+                    <div id="tab-email" class="hidden" role="tabpanel" aria-labelledby="tabbtn-email">
+                        <div class="form-group">
+                            <label for="twofa-code-email">Enter the 6‑digit email code</label>
+                            <input type="text" id="twofa-code-email" name="code-email" inputmode="numeric" placeholder="123456">
+                            <small class="field-error" aria-live="assertive"></small>
+                        </div>
+                        <div class="form-row" style="justify-content:flex-end; gap:.75rem;">
+                            <button type="button" id="twofa-resend" class="btn btn-secondary">Send code</button>
+                        </div>
+                    </div>
+                    <div id="tab-recovery" class="hidden" role="tabpanel" aria-labelledby="tabbtn-recovery">
+                        <div class="form-group">
+                            <label for="twofa-code-recovery">Enter a recovery code</label>
+                            <input type="text" id="twofa-code-recovery" name="code-recovery" inputmode="text" placeholder="XXXXXXXXXX">
+                            <small class="field-error" aria-live="assertive"></small>
+                        </div>
+                    </div>
+
+                    <div class="form-row" style="justify-content: flex-end; gap: .75rem;">
                         <button type="submit" class="btn btn-primary" style="flex:1;">Verify</button>
                     </div>
                     <p class="switch-text"><a href="{{ route('auth') }}">Use a different account</a></p>
@@ -40,7 +67,6 @@
                         <i class="fa-solid fa-circle-check" style="color:#16a34a;font-size:2rem;margin-bottom:.5rem;"></i>
                         <h3>Verified</h3>
                         <p>2FA code accepted. You're securely signed in.</p>
-                        <a href="{{ route('home') }}" class="btn btn-primary w-full">Go to dashboard</a>
                     </div>
                 </div>
             </div>

--- a/resources/views/emails/twofa_code.blade.php
+++ b/resources/views/emails/twofa_code.blade.php
@@ -1,0 +1,16 @@
+@extends('emails.layouts.app')
+
+@section('subject', 'Your sign-in code')
+
+@section('content')
+  <h1 style="font-size:22px; font-weight:800; color:#1C4532; margin:0 0 8px;">Your sign-in code</h1>
+  <p style="margin: 0 0 12px;">Hi {{ $user->name }},</p>
+  <p style="margin: 0 0 12px;">Use the code below to finish signing in to your account.</p>
+  <div style="margin:16px 0 12px; padding:16px; background:#F8FAFC; border:1px solid #E2E8F0; border-radius:12px; text-align:center;">
+    <div style="font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size:28px; font-weight:800; letter-spacing:6px; color:#0F172A;">
+      {{ $code }}
+    </div>
+    <p class="muted" style="margin:10px 0 0; font-size:12px; color:#64748b;">This code expires in {{ $expiresIn }} minutes.</p>
+  </div>
+  <p class="muted" style="margin-top:18px;">If you didn’t try to sign in, you can safely ignore this email.</p>
+@endsection

--- a/resources/views/emails/twofa_code_plain.blade.php
+++ b/resources/views/emails/twofa_code_plain.blade.php
@@ -1,0 +1,8 @@
+Your sign-in code
+
+Hi {{ $user->name }},
+
+Use this code to finish signing in. It expires in {{ $expiresIn }} minutes:
+{{ $code }}
+
+If you didn’t try to sign in, you can ignore this email.

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -58,4 +58,7 @@ Route::prefix('api/auth')->group(function () {
         Route::post('2fa/enable', [TwoFactorController::class, 'enable']);
         Route::post('2fa/disable', [TwoFactorController::class, 'disable']);
     });
+
+    // Email code send (does not require JWT yet; validates credentials)
+    Route::post('2fa/email/send', [ApiAuthController::class, 'sendEmailCode']);
 });


### PR DESCRIPTION
This pull request adds support for two-factor authentication (2FA) using one-time codes sent via email, in addition to authenticator apps and recovery codes. It introduces backend logic for generating and verifying email codes, a notification for sending codes to users, and updates the frontend to provide a tabbed interface for selecting the 2FA method. The login flow and UI have been enhanced to allow users to request and enter email codes, improving accessibility for users without authenticator apps.

**Backend: Email-based 2FA support**
* Added methods to `TwoFactorService` for generating and verifying one-time email codes, stored temporarily in cache and consumed on successful verification.
* Implemented a new API endpoint (`sendEmailCode`) in `ApiAuthController` to send a one-time code to the user's verified email after credential verification, using a new notification class. [[1]](diffhunk://#diff-fc163e928b56125fd51b43141a421f666bc1484a20ba58c73243a3600bc282bdR81-R110) [[2]](diffhunk://#diff-f964323300256bfa4de7b9e3b58bcffb9b225f006721e50da53cb48e96749d9fR1-R41)
* Updated login logic to accept and verify `email_code` as an alternative to authenticator or recovery codes, including error handling and validation. [[1]](diffhunk://#diff-fc163e928b56125fd51b43141a421f666bc1484a20ba58c73243a3600bc282bdR25) [[2]](diffhunk://#diff-fc163e928b56125fd51b43141a421f666bc1484a20ba58c73243a3600bc282bdR39-R47) [[3]](diffhunk://#diff-fc163e928b56125fd51b43141a421f666bc1484a20ba58c73243a3600bc282bdL54-R61)

**Frontend: Tabbed 2FA method selection and email code flow**
* Redesigned the two-factor authentication page to use tabs for selecting between authenticator app, email code, or recovery code, with corresponding input fields and labels. [[1]](diffhunk://#diff-aefc36157c4cc233d0bf74da79d941a893e58a1381de76ce0dda01f60d678c27L15-R15) [[2]](diffhunk://#diff-aefc36157c4cc233d0bf74da79d941a893e58a1381de76ce0dda01f60d678c27R25-R59)
* Updated `twofa.js` to handle tab switching, input validation for each method, and the process for requesting and verifying email codes, including user feedback and notices. [[1]](diffhunk://#diff-d29d15500a2c74fba0f71e1cff754391d3429aaa34c7fded8bea4d3f88c6d796L4-R49) [[2]](diffhunk://#diff-d29d15500a2c74fba0f71e1cff754391d3429aaa34c7fded8bea4d3f88c6d796R59-R101) [[3]](diffhunk://#diff-d29d15500a2c74fba0f71e1cff754391d3429aaa34c7fded8bea4d3f88c6d796L76-R141) [[4]](diffhunk://#diff-d29d15500a2c74fba0f71e1cff754391d3429aaa34c7fded8bea4d3f88c6d796L106-R210)

**Notifications and email templates**
* Added new notification class `TwoFactorEmailCode` for sending email codes, and created both HTML and plain-text email templates for the sign-in code. [[1]](diffhunk://#diff-f964323300256bfa4de7b9e3b58bcffb9b225f006721e50da53cb48e96749d9fR1-R41) [[2]](diffhunk://#diff-6779ec85cb3d4c67a14e5dfc1f7414d36dd4fc4fa11ae18f496b934844358d4eR1-R16) [[3]](diffhunk://#diff-a60270aa97c81b28ee55f239130794f9a22fb1ab66c113c51874804e03fd9aabR1-R8)