### PR TITLE
Feat/add new waste items

### DIFF
--- a/app/Models/Material.php
+++ b/app/Models/Material.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Material extends Model
+{
+    protected $fillable = ['name'];
+
+    /**
+     * @return HasMany<WasteItem, static>
+     */
+    public function wasteItems(): HasMany
+    {
+        /** @phpstan-ignore-next-line return.type */
+        return $this->hasMany(WasteItem::class);
+    }
+}

--- a/app/Models/Material.php
+++ b/app/Models/Material.php
@@ -3,18 +3,21 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Material extends Model
 {
     protected $fillable = ['name'];
 
     /**
-     * @return HasMany<WasteItem, static>
+     * Many-to-many: this material belongs to many waste items.
+     *
+     * @return BelongsToMany<WasteItem, static>
      */
-    public function wasteItems(): HasMany
+    public function wasteItems(): BelongsToMany
     {
         /** @phpstan-ignore-next-line return.type */
-        return $this->hasMany(WasteItem::class);
+        return $this->belongsToMany(WasteItem::class)
+            ->withTimestamps();
     }
 }

--- a/app/Models/WasteItem.php
+++ b/app/Models/WasteItem.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class WasteItem extends Model
@@ -37,11 +38,14 @@ class WasteItem extends Model
     }
 
     /**
-     * @return BelongsTo<Material, static>
+     * Many-to-many: this waste item has many materials.
+     *
+     * @return BelongsToMany<Material, static>
      */
-    public function material(): BelongsTo
+    public function materials(): BelongsToMany
     {
         /** @phpstan-ignore-next-line return.type */
-        return $this->belongsTo(Material::class);
+        return $this->belongsToMany(Material::class)
+            ->withTimestamps();
     }
 }

--- a/app/Models/WasteItem.php
+++ b/app/Models/WasteItem.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class WasteItem extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'generator_id',
+        'material_id',
+        'title',
+        'images',
+        'estimated_weight',
+        'condition',
+        'location',
+        'notes',
+    ];
+
+    protected $casts = [
+        'images' => 'array',
+        'location' => 'array',
+        'estimated_weight' => 'decimal:2',
+    ];
+
+    /**
+     * @return BelongsTo<User, static>
+     */
+    public function generator(): BelongsTo
+    {
+        /** @phpstan-ignore-next-line return.type */
+        return $this->belongsTo(User::class, 'generator_id');
+    }
+
+    /**
+     * @return BelongsTo<Material, static>
+     */
+    public function material(): BelongsTo
+    {
+        /** @phpstan-ignore-next-line return.type */
+        return $this->belongsTo(Material::class);
+    }
+}

--- a/database/migrations/2025_09_24_000300_create_materials_table.php
+++ b/database/migrations/2025_09_24_000300_create_materials_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('materials', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('materials');
+    }
+};

--- a/database/migrations/2025_09_24_000400_create_waste_items_table.php
+++ b/database/migrations/2025_09_24_000400_create_waste_items_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('waste_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('generator_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('material_id')->constrained('materials');
+            $table->string('title');
+            $table->json('images')->nullable();
+            $table->decimal('estimated_weight', 10, 2)->nullable();
+            $table->enum('condition', ['good', 'fixable', 'scrap'])->default('good');
+            $table->json('location')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['generator_id', 'material_id']);
+            $table->index('condition');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('waste_items');
+    }
+};

--- a/database/migrations/2025_09_24_000500_create_material_waste_item_table.php
+++ b/database/migrations/2025_09_24_000500_create_material_waste_item_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('material_waste_item', function (Blueprint $table) {
+            $table->foreignId('material_id')->constrained('materials')->cascadeOnDelete();
+            $table->foreignId('waste_item_id')->constrained('waste_items')->cascadeOnDelete();
+            $table->timestamps();
+            $table->primary(['material_id', 'waste_item_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('material_waste_item');
+    }
+};


### PR DESCRIPTION
This pull request introduces two new Eloquent models, `Material` and `WasteItem`, along with their respective database migrations and a pivot table to support a many-to-many relationship between materials and waste items. The changes establish the database structure and model relationships necessary for managing waste items and their associated materials in the application.

**Database schema additions:**

* Added migration to create the `materials` table, including a unique `name` field and timestamps.
* Added migration to create the `waste_items` table with fields for generator, material, title, images, estimated weight, condition, location, notes, timestamps, and soft deletes, as well as relevant indexes.
* Added migration to create the `material_waste_item` pivot table to support a many-to-many relationship between materials and waste items, including composite primary key and cascade deletes.

**Model and relationship setup:**

* Introduced the `Material` model with a many-to-many relationship to `WasteItem` via the `wasteItems()` method.
* Introduced the `WasteItem` model with soft deletes, a belongs-to relationship to `User` (generator), and a many-to-many relationship to `Material` via the `materials()` method.
